### PR TITLE
add xnaas.info

### DIFF
--- a/pages.txt
+++ b/pages.txt
@@ -280,3 +280,4 @@ https://timotijhof.net/
 https://jeffhuang.com/
 https://kidl.at/
 https://dusanmitrovic.xyz/
+https://xnaas.info


### PR DESCRIPTION
The HTML and CSS are ~1.86KB transferred (~2KB before compression), the massive favicon.ico
is the bulk of the site at 12.12KB transfered (32.21KB before compression).
