### PR TITLE
Add https://qubyte.codes

### DIFF
--- a/pages.txt
+++ b/pages.txt
@@ -280,3 +280,4 @@ https://timotijhof.net/
 https://jeffhuang.com/
 https://kidl.at/
 https://dusanmitrovic.xyz/
+https://qubyte.codes/


### PR DESCRIPTION
The GTMetrix report gives a compressed transfer size of 45.9KB, so I'd expect other measurements to yield a similar result.

https://gtmetrix.com/reports/qubyte.codes/lM00qQ9q/