### PR TITLE
add cleberg.io

### DIFF
--- a/pages.txt
+++ b/pages.txt
@@ -297,3 +297,4 @@ https://netbros.com/
 https://ampersandia.net/
 https://casperlefantom.net/
 https://rectangles.app/
+https://cleberg.io/


### PR DESCRIPTION
`cleberg.io` is currently measuring at `31.7KB` uncompressed, per the following report: https://gtmetrix.com/reports/cleberg.io/oELOMWoN/