### PR TITLE
Adds xwx.moe

### DIFF
--- a/pages.txt
+++ b/pages.txt
@@ -282,6 +282,7 @@ https://cri.cl/
 https://palashbauri.in/
 https://viniciushansen.github.io/
 https://mha.fi/
+https://xwx.moe/
 https://pdgonzalez872.github.io/
 https://oopsallmarquees.com/
 https://pumpopoly.com/


### PR DESCRIPTION
xwx.moe weighs 220kb uncompressed (208kb compressed), including the language redirection page (https://xwx.moe/) and index pages (https://xwx.moe/en/ and https://xwx.moe/eo/).

https://yellowlab.tools/result/ga3mi2foo3 (Language redirect)
https://yellowlab.tools/result/ga3miwvyr3 (Index)
https://gtmetrix.com/reports/xwx.moe/131nU965/ (Both)
