### PR TITLE
Fix wrong <a src=…> attributes in badge templates

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -46,7 +46,7 @@
       (1.4kB)
     </summary>
     <pre><code>
-  &lt;a title="250kb club page" src="https://250kb.club/{{ page.slug }}"&gt;
+  &lt;a title="250kb club page" href="https://250kb.club/{{ page.slug }}"&gt;
     &lt;img
       alt="badge: proud member of the 250kb club"
       src="https://250kb.club/simple_badge_dark.png"
@@ -61,7 +61,7 @@
       (1.7kB)
     </summary>
     <pre><code>
-  &lt;a title="250kb club page" src="https://250kb.club/{{ page.slug }}"&gt;
+  &lt;a title="250kb club page" href="https://250kb.club/{{ page.slug }}"&gt;
     &lt;img
       alt="badge: proud member of the 250kb club"
       src="https://250kb.club/simple_badge_bright.png"
@@ -76,7 +76,7 @@
       (4.0kB)
     </summary>
     <pre><code>
-  &lt;a title="250kb club page" src="https://250kb.club/{{ page.slug }}"&gt;
+  &lt;a title="250kb club page" href="https://250kb.club/{{ page.slug }}"&gt;
     &lt;img
       alt="badge: proud member of the 250kb club"
       src="https://250kb.club/color_badge_bright.png"
@@ -91,7 +91,7 @@
       (5.7kB)
     </summary>
     <pre><code>
-  &lt;a title="250kb club page" src="https://250kb.club/{{ page.slug }}"&gt;
+  &lt;a title="250kb club page" href="https://250kb.club/{{ page.slug }}"&gt;
     &lt;img
       alt="badge: proud member of the 250kb club"
       src="https://250kb.club/color_badge_dark.png"


### PR DESCRIPTION
Found thanks to `tidy`:

```
line 304 column 1 - Warning: <a> proprietary attribute "src"
```