### PR TITLE
Adding Hobospider132.github.io

### DIFF
--- a/pages.txt
+++ b/pages.txt
@@ -342,3 +342,4 @@ https://arciniega.one/
 http://www.sayorivill.me/
 https://pigeon.codeberg.page/
 https://txt.allfoxesare.gay/
+https://hobospider132.github.io/


### PR DESCRIPTION
Site: https://hobospider132.github.io/
Repo: https://github.com/Hobospider132/hobospider132.github.io 
Size: 35.4 kb

Not sure if this is required:

https://gtmetrix.com/reports/hobospider132.github.io/uBNHZxtU/