### PR TITLE
Add bmoat.com

### DIFF
--- a/pages.txt
+++ b/pages.txt
@@ -7,6 +7,7 @@ https://1mb.club/
 https://10kbclub.com/
 https://no-js.club/
 https://abridge.netlify.app/
+https://bmoat.com/
 https://unixsheikh.com/
 https://www.usecue.com
 https://lecaro.me


### PR DESCRIPTION
[https://bmoat.com/](https://bmoat.com/) is 23.4KB according to yellowlab.tools: [https://yellowlab.tools/result/gkadc899mf/rule/totalWeight](https://yellowlab.tools/result/gkadc899mf/rule/totalWeight)